### PR TITLE
Implement WeakReference "hack" for PHP < 7.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 Symfony Polyfill / Php74
 ========================
 
-This component provides functions added to PHP 7.4 core:
+This component provides functions and classes added to PHP 7.4 core:
 
 - [`get_mangled_object_vars`](https://php.net/get_mangled_object_vars)
 - [`mb_str_split`](https://php.net/mb_str_split)
 - [`password_algos`](https://php.net/password_algos)
+- [`WeakReference`](https://www.php.net/manual/en/class.weakreference)
 
 More information can be found in the
 [main Polyfill README](https://github.com/symfony/polyfill/blob/master/README.md).

--- a/WeakReference.php
+++ b/WeakReference.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Symfony\Polyfill\Php74;
+
+/**
+ * WeakReference class implementation for PHP < 7.4
+ */
+class WeakReference
+{
+    protected $ref;
+
+    protected function __construct()
+    {
+    }
+
+    /**
+     * @param $object
+     * @return WeakReference
+     */
+    public static function create($object): WeakReference
+    {
+        $reference = new WeakReference();
+        $reference->ref = $object;
+
+        return $reference;
+    }
+
+    /**
+     * @return object|null Returns reference on the stored object.
+     *                     If reference counter returns 0, returns null and unsets object
+     */
+    public function &get()
+    {
+        if (!$this->refcount($this->ref)) {
+            unset($this->ref);
+        }
+
+        return $this->ref;
+    }
+
+    /**
+     * Uses debug_zval_dump function to count object references
+     */
+    protected function refcount($var)
+    {
+        ob_start();
+        debug_zval_dump($var);
+        $dump = ob_get_clean();
+
+        $matches = [];
+        preg_match('/refcount\(([0-9]+)/', $dump, $matches);
+
+        $count = $matches[1];
+
+        //3 references are added, including when calling debug_zval_dump(), so we need to subtract them
+        return $count - 3;
+    }
+}

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -24,3 +24,6 @@ if (!function_exists('mb_str_split') && function_exists('mb_substr')) {
 if (!function_exists('password_algos')) {
     function password_algos() { return p\Php74::password_algos(); }
 }
+if (!class_exists("WeakReference")) {
+    final class WeakReference extends p\WeakReference {}
+}


### PR DESCRIPTION
Using refcount value, provided by "debug_zval_dump", we can implement smth. similar to WeakReference from PHP 7.4. 